### PR TITLE
Remove extra colon from "Tweet about us" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Victoria Startup Jobs
 
-[Tweet about us!](https://twitter.com/intent/tweet?text=I%20found%20a%20job%20on%20the%20Victoria%20Startup%20Jobs%20repo!&via=victoriastartup&url=http:%3A%2F%2Fgithub.com/sendwithus/vic-startup-jobs)
+[Tweet about us!](https://twitter.com/intent/tweet?text=I%20found%20a%20job%20on%20the%20Victoria%20Startup%20Jobs%20repo!&via=victoriastartup&url=http%3A%2F%2Fgithub.com/sendwithus/vic-startup-jobs)
 
 
 A well-maintained list of available startup jobs in Victoria BC. 


### PR DESCRIPTION
That extra colon made me look like more of a Twitter fool than usual!