### PR TITLE
Updating link checker to print out links that redirect

### DIFF
--- a/link_checker/check.py
+++ b/link_checker/check.py
@@ -14,6 +14,7 @@ user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36
 
 class LinkChecker(object):
     bad_links = []
+    maybe_bad_links = []
     already_seen = []
     headers = {
         'user-agent': user_agent
@@ -29,17 +30,17 @@ class LinkChecker(object):
         try:
             response = requests.get(link, headers=self.headers, allow_redirects=True, stream=True)
 
+            try:
+                domain = re.match(r'https?://([^/]+)/', link).groups()[0]
+            except:
+                domain = '--no domain match--'
+
             # print status and URL info for links resulting in non-OK responses
             # so we can clean up the jobs listing
             if response.status_code >= 400:
-                try:
-                    domain = re.match(r'https?://([^/]+)/', link).groups()[0]
-                except:
-                    domain = '--no domain match--'
-                print('-', response.status_code, domain, text, link)
                 self.bad_links.append((response.status_code, domain, text, link))
-            else:
-                valid = True
+            elif response.history and response.history[0].status_code in (301, 302):
+                self.maybe_bad_links.append((response.status_code, domain, text, link))
         except requests.exceptions.MissingSchema:
             # in-page anchor links will trigger this error
             pass
@@ -47,11 +48,9 @@ class LinkChecker(object):
             # ignore mailto: link errors, but print anything else, as it's
             # likely incorrect URL formatting in the markdown
             if not link.startswith('mailto:'):
-                print('Error fetching URL, invalid URL schema:', e, file=sys.stderr)
                 self.bad_links.append(('Invalid schema', link))
         except Exception as e:
             # something else happened, print to diagnose
-            print('Error testing URL:', link, text, 'Exception:', e, file=sys.stderr)
             self.bad_links.append(('Error: {}'.format(e), link))
         finally:
             if response:
@@ -68,6 +67,11 @@ class LinkChecker(object):
         pool.join()
 
         print('Done checking {} URLs'.format(len(links)))
+
+        if self.maybe_bad_links:
+            print('\n-- Redirects that MIGHT BE Bad Links --')
+            for link_info in self.maybe_bad_links:
+                print(*link_info)
 
         if self.bad_links:
             print('\n-- Bad Links --')


### PR DESCRIPTION
Redirected job pages MAY BE removed jobs that simply redirect to another page.