### PR TITLE
Remove fulfilled Waterworth position

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ Keep in mind that companies may have job postings on their own site that are not
 
 
 #### [Bambora North America](https://www.bambora.com/en/ca/) (👩‍💻 Co-Op / Intern Friendly)
-* [Full-Stack Developer](https://career.bambora.com/jobs/229617-full-stack-developer)
-* [DevOps Engineer](https://career.bambora.com/jobs/243833-devops-engineer)
 
 #### [Barnacle Systems](https://www.brnkl.io/) (👩‍💻 Co-Op / Intern Friendly)
 * [Software Developer](https://www.brnkl.io/wp-content/uploads/2019/02/20190228_BRNKL-Job-Description_Software-Developer.pdf)

--- a/README.md
+++ b/README.md
@@ -251,7 +251,6 @@ Keep in mind that companies may have job postings on their own site that are not
 #### [Watershed Partners](https://watershed.co/)
 
 #### [Waterworth ](https://waterworth.net/)
-* [Full Stack Developer](https://waterworth.net/careers/)
 * [Customer Success Manager](https://waterworth.net/careers/)
 
 #### [White Ops](https://www.whiteops.com/)


### PR DESCRIPTION
Had to remove bambora postings because they gave 404s when I ran check.py

Also had issues with check.py sometimes complaining about vivitrolabs.com & starfishmedical.com
![image](https://user-images.githubusercontent.com/22509134/61551154-41fc6b80-aa09-11e9-8e29-7f4af9df5655.png)

But since it sometimes didn't seem to have issues, I assumed they aren't actually broken links.