### PR TITLE
Handle UTF8 in link checker

### DIFF
--- a/link_checker/check.py
+++ b/link_checker/check.py
@@ -79,7 +79,7 @@ class LinkChecker(object):
         self.already_seen.append(link)
 
     def parse_page(self, md_file):
-        raw_markdown = open(md_file, 'r').read()
+        raw_markdown = open(md_file, 'r', encoding="utf8").read()
         links = re.findall(r'\[([^\]]+)\]\(([^\)]+)\)', raw_markdown)
 
         pool = Pool(3)


### PR DESCRIPTION
When running the link checker on Win10 (I know, gross), I got this

```
$ python link_checker/check.py 
Traceback (most recent call last):
  File "link_checker/check.py", line 102, in <module>
    if not LinkChecker().parse_page(markdown_file):
  File "link_checker/check.py", line 82, in parse_page
    raw_markdown = open(md_file, 'r').read()
  File "C:\Users\Steven\AppData\Local\Programs\Python\Python38\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 1612: character maps to <undefined>
```

Set the `open()` to treat the file as UTF8 instead of Windows Code Page 1252.