### PR TITLE
Revela closes one position, opens another

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Keep in mind that companies may have job postings on their own site that are not
 #### [regroove](https://regroove.ca/) (👩‍💻 Co-Op / Intern Friendly)
 
 #### [Revela Systems](https://www.revela.io/) (👩‍💻 Co-Op / Intern Friendly)
-* [Junior DevOps Engineer](https://www.revela.io/2020-devops-engineer/)
+* [Intern Cloud Developer](https://www.revela.io/2020-intern-cloud-developer/)
 
 #### [RevenueWire](https://www.revenuewire.com/) (👩‍💻 Co-Op / Intern Friendly)
 * [Developer](https://www.revenuewire.com/careers/)


### PR DESCRIPTION
Revela closes its posting for "Junior Devops Engineer", and posts another similar position, "Intern Cloud Developer"

Local problems from link_checker:
* [ ] --- "BCDevExchange" https://www2.gov.bc.ca/gov/content/careers-myhr/job-seekers/current-job-postings (FAILED SSL HANDSHAKE)