### PR TITLE
ci: use focal (Ubuntu 20.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: generic
 
+dist: focal
 addons:
   apt:
     update: true

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Keep in mind that companies may have job postings on their own site that are not
 * [Co-op Developer](https://www.crowdcontent.com/coop-developer/)
 * [Sales Administrator Co-op](https://www.crowdcontent.com/sales-administrator-co-op/)
 * [Account Executive](https://www.crowdcontent.com/current-openings-account-executive/)
-* [Editorial Content Manager](https://www.crowdcontent.com/senior-project-manager/)
+* [Editorial Content Manager](https://www.crowdcontent.com/editorial-content-manager/)
 
 #### [Cuboh](https://www.cuboh.com/careers) (👩‍💻 Co-Op / Intern Friendly)
 * [Digital Sales Representative](https://cubohcareers.humi.ca/job-board/sales/5846)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Keep in mind that companies may have job postings on their own site that are not
 #### [Atomic Crayon](http://www.atomiccrayon.com/)
 * [Full-Stack Web Developer](https://atomiccrayon.com/career-opportunities#job1)
 
-#### [Audette](https://audette.io/)
+#### [Audette](https://www.audette.io/)
 
 #### [Avalanche Insights](https://www.avalancheinsights.com/)
 * [Software Engineer](https://jobs.lever.co/AvalancheInsights/444f2d11-9d06-4d53-8f2f-33031d2fe018)


### PR DESCRIPTION
The current builds are failing because HTTPS certificates are not up to date, eg lots of links look like this:

```log
$ link_checker/check.sh README.md
📊 Found 244 links in this document to test.
🔓 [---] watershed.co's SSL certificate seems invalid!
🔓 [---] boards.greenhouse.io's SSL certificate seems invalid!
🔓 [---] boards.greenhouse.io's SSL certificate seems invalid!
```

This is because the default build environment for travis is [Ubuntu 16.04](https://docs.travis-ci.com/user/reference/overview#linux). The 16.04 version number is actually a date, and Ubuntu Xenial was released in 2016! It's standard support window is now closed ([April 2021](https://wiki.ubuntu.com/Releases)).

Even though we update ca-certificates (the most common package that controls which root certificate authorities can be trusted), the version of ca-certificates for xenial hasn't been updated [since January](https://www.ubuntuupdates.org/package/core/xenial/main/security/ca-certificates)!

If we use Ubuntu 20.04 (the current long term support (LTS) release), then we should be good for another couple years.