### PR TITLE
fix: some user-agent sniffers block curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Keep in mind that companies may have job postings on their own site that are not
 
 #### [Redbrick](https://rdbrck.com/) (👩‍💻 Co-Op / Intern Friendly)
 * [Payroll & Benefits Admin](https://rdbrck.bamboohr.com/jobs/view.php?id=147)
-* [Sfotware Engineer](https://rdbrck.bamboohr.com/jobs/view.php?id=149)
+* [Software Engineer](https://rdbrck.bamboohr.com/jobs/view.php?id=149)
 
 #### [Regroove](https://regroove.ca) (👩‍💻 Co-Op / Intern Friendly)
 * [Cloud Solutions Consultant](https://regroove.ca/careers/cloud-solutions-consultant/)
@@ -248,7 +248,6 @@ Keep in mind that companies may have job postings on their own site that are not
 #### [Revela Systems](https://www.revela.io/)
 
 #### [RingPartner](https://ringpartner.com/) (👩‍💻 Co-Op / Intern Friendly)
-* [Growth Product Manager](https://buyerlink.applytojob.com/apply/MjKAX8aDHE/Growth-Product-Manager) 
 
 #### [Rooof](https://www.rooof.com) (👩‍💻 Co-Op / Intern Friendly)
 
@@ -265,7 +264,7 @@ Keep in mind that companies may have job postings on their own site that are not
 #### [STN Video (formerly SendtoNews)](https://www.stnvideo.com/careers/)
 * [Project Manager](https://secure.collage.co/jobs/sendtonews/28595)
 * [Manager of People Operations](https://secure.collage.co/jobs/sendtonews/30911)
-* [Director of People Operations](https://secure.collage.co/jobs/sendtonews/29682)
+
 
 #### [SparkLIT](https://www.sparklit.com/)
 * [Intermediate Software Engineer, Full Stack](https://www.sparklit.com/careers/#full-stack)

--- a/link_checker/check.sh
+++ b/link_checker/check.sh
@@ -106,7 +106,15 @@ test_link () {
 		return 1 # Missing scheme, www.example.com will be linked to a file in the repo
 
 	else
-		http_code=$(curl --location --silent -o /dev/null -w '%{http_code}' "${link}")
+		http_code="$(
+			curl \
+			--header 'user-agent: sendwithus-link-checker/2022.06.07' \
+			--location \
+			--silent \
+			--output /dev/null \
+			--write-out '%{http_code}' \
+			"${link}"
+		)"
 		curl_status=$?
 
 		# We follow redirects (--location), but 3xx-series HTTP codes could still end up here.

--- a/link_checker/check.sh
+++ b/link_checker/check.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# User-Agent string, update version as needed
+UA_STRING=${UA_STRING:-'sendwithus-link-checker/2022.06.07'}
+
 # Check deps
 if ((BASH_VERSINFO[0] < 4)); then
 	echo "You need bash 4 or later to run this script."
@@ -108,7 +111,7 @@ test_link () {
 	else
 		http_code="$(
 			curl \
-			--header 'user-agent: sendwithus-link-checker/2022.06.07' \
+			--header "user-agent: ${UA_STRING}" \
 			--location \
 			--silent \
 			--output /dev/null \


### PR DESCRIPTION
Currently without setting a user agent, curl sends the header: `user-agent: curl/7.68.0`, and some sites blacklist curl.. 

```console
> curl --dump-header - https://secure.collage.co/jobs/sendtonews/30911                                   
HTTP/2 403 
server: awselb/2.0
date: Wed, 08 Jun 2022 00:02:36 GMT
content-type: text/html
content-length: 118

<html>
<head><title>403 Forbidden</title></head>
<body><center><h1>403 Forbidden</h1></center></body>
</html>
```

If we make up a valid header, services that forbid curl let us by! 

```console
> curl -H 'user-agent: sendwithus-link-checker/2022.06.07' --dump-header - https://secure.collage.co/jobs/sendtonews/30911
HTTP/2 200 
date: Wed, 08 Jun 2022 00:05:36 GMT
content-type: text/html; charset=utf-8
[...More Headers]

<!DOCTYPE html><html prefix="og: http://ogp.me/ns#"><head>blah blah blah
```

We still treat 3XX response codes as okay though, even if they redirect to a "position closed" page that responds with 200. 

```console
> curl -H 'user-agent: sendwithus-link-checker/2022.06.07' --dump-header - https://secure.collage.co/jobs/sendtonews/29682                          
HTTP/2 302 
date: Tue, 07 Jun 2022 23:59:39 GMT
content-type: text/html; charset=utf-8
location: https://secure.collage.co/jobs/sendtonews/closed
[...More Headers]

<html><body>You are being <a href="https://secure.collage.co/jobs/sendtonews/closed">redirected</a>.</body></html>
```