### PR TITLE
ci: fix link checker comment on PR workflow

### DIFF
--- a/.github/workflows/comment-on-pr.yaml
+++ b/.github/workflows/comment-on-pr.yaml
@@ -19,12 +19,21 @@ jobs:
         id: report
         with:
           name: report
+          path: ${{ github.workspace }}/reports
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read PR number
         id: pr-number
-        run: echo "number=${$(basename -- ${{ steps.report.outputs.download-path }}/*.md)%.*}" >> "$GITHUB_OUTPUT"
+        # Glob the downloaded folder for reports, should only be one in the artifact;
+        # Then extract the PR number from the report name and write it to the output file.
+        run: |
+          reports=( "${{ steps.report.outputs.download-path }}/*.md" )
+          if [ ${#reports[@]} -ne 1 ]; then
+            echo "Expected 1 report, found ${#reports[@]}"
+            exit 1
+          fi
+          echo "number=$(basename -- ${reports[0]%.*})" >> "$GITHUB_OUTPUT"
 
       - name: Find Comment
         uses: peter-evans/find-comment@v3

--- a/.github/workflows/comment-on-pr.yaml
+++ b/.github/workflows/comment-on-pr.yaml
@@ -33,7 +33,7 @@ jobs:
             echo "Expected 1 report, found ${#reports[@]}"
             exit 1
           fi
-          echo "number=$(basename -- ${reports[0]%.*})" >> "$GITHUB_OUTPUT"
+          echo "number=$(basename -- ${reports[0]} .md)" >> "$GITHUB_OUTPUT"
 
       - name: Find Comment
         uses: peter-evans/find-comment@v3

--- a/.github/workflows/comment-on-pr.yaml
+++ b/.github/workflows/comment-on-pr.yaml
@@ -8,7 +8,7 @@ on:
       - completed
 
 jobs:
-  check-links:
+  comment-on-pr:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion != 'skipped'
     permissions:
@@ -46,7 +46,7 @@ jobs:
 
       # An comment exists here already, and now there's no issues from the link checker
       - name: Clear report
-        if: steps.fc.outputs.comment-id != ''
+        if: ${{ github.event.workflow_run.conclusion == 'success' && steps.fc.outputs.comment-id != '' }}
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
@@ -57,7 +57,7 @@ jobs:
 
       # No comment exists here, and link checking found no issues
       - name: No issues
-        if: steps.fc.outputs.comment-id == ''
+        if: ${{ github.event.workflow_run.conclusion == 'success' && steps.fc.outputs.comment-id == '' }}
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ steps.pr-number.outputs.number }}
@@ -71,7 +71,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ steps.pr-number.outputs.number }}
-          body-path: "report.md"
+          body-path: "reports/${{ steps.pr-number.outputs.number }}.md"
 
       # Update existing comment with new report
       - name: Update report
@@ -79,5 +79,5 @@ jobs:
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
+          body-path: "reports/${{ steps.pr-number.outputs.number }}.md"
           edit-mode: replace
-          body-path: report.md

--- a/.github/workflows/comment-on-pr.yaml
+++ b/.github/workflows/comment-on-pr.yaml
@@ -1,6 +1,11 @@
 name: Comment on PR
 
 on:
+  # This workflow doesn't show up in the PR, only in the actions tab. We need to use this
+  # separated workflow because pull_request events from forks are not allowed to have a
+  # write-token, and we need that to comment on the incoming PR. Changes to this file will
+  # not take place during the PR, this workflow runs using the version of this file on the
+  # default branch.
   workflow_run:
     workflows:
       - Link Checking


### PR DESCRIPTION
Fiddling around a bit more with GHA, sorry for the noise! It's a little difficult to contribute this kind of workflow without being an owner on this repo since the tokens granted to PRs from forks don't include permissions to write comments on forks. I've now confirmed this workflow's functionality on our fork, and I _think_ it should work fine here now too. I'm going to close #316 one more time and wait for this to land before trying once more there. 

I hope this is correct now, at least I have evidence of it working on our fork: https://github.com/revela-systems/vic-startup-jobs/pull/7#issuecomment-2008548077